### PR TITLE
ci: use a non default GITHUB_TOKEN to trigger workflow

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -26,7 +26,8 @@ jobs:
         with:
           command: release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # use a non default GITHUB_TOKEN to trigger other workflows
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
   # Create a PR with the new versions and changelog, preparing the next release.
@@ -48,5 +49,6 @@ jobs:
         with:
           command: release-pr
         env:
+          # use the default GITHUB_TOKEN to not trigger other workflows
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.mise.toml
+++ b/.mise.toml
@@ -34,6 +34,7 @@ run = [
 run = "cargo hack check --each-feature --no-dev-deps"
 
 [tasks."build"]
+depends = ["install:rustcomponents"]
 run = "cargo build"
 
 [tasks."format"]
@@ -63,11 +64,13 @@ run = [
 
 
 [tasks."lint:dependencies"]
+depends = ["install:rustcomponents"]
 run = ["cargo machete --with-metadata"]
 # check unused with cargo-machete or cargo-udeps
 # TODO check outdated
 
 [tasks."test"]
+depends = ["install:rustcomponents"]
 run = [
     "cargo nextest run",
     # "cargo test --doc",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated environment variable from `GITHUB_TOKEN` to `RELEASE_PLZ_TOKEN` in workflow jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->