### PR TITLE
feat!(github): change the computation of workflow_xxx ids & name

### DIFF
--- a/config/transformers/github_events.vrl
+++ b/config/transformers/github_events.vrl
@@ -132,10 +132,10 @@ if exists(.body.package) {
             "timestamp": ts,
         },
         "subject": {
-            "id": to_string(.body.workflow_run.id) ?? "", # or .body.workflow_run.workflow_id ?
+            "id": to_string!(.body.workflow_run.id) + "/" + to_string!(.body.workflow_run.run_attempt) , # or .body.workflow_run.workflow_id, integration of run_number ?
             "type": "pipelineRun",
             "content": {
-                "pipelineName": .body.workflow_run.name,
+                "pipelineName": (repo_full_name + "/" + .body.workflow_run.name) ?? "",
                 "url": .body.workflow_run.html_url
             }
         }
@@ -160,13 +160,14 @@ if exists(.body.package) {
             "source": .body.workflow_job.url,
         },
         "subject": {
-            "id": to_string(.body.workflow_job.id) ?? "", # or .body.workflow_run.workflow_id ?
+            "id": to_string!(.body.workflow_job.id) + "/" + to_string!(.body.workflow_job.run_attempt),
             "type": "taskRun",
             "content": {
-                "taskName": .body.workflow_job.name,
+                # define an "absolute" name to avoid conflicts with other entities from other contexts
+                "taskName": (repo_full_name + "/" + .body.workflow_job.workflow_name + "/" + .body.workflow_job.name) ?? .body.workflow_job.name,
                 "url": .body.workflow_job.html_url,
                 "pipelineRun": {
-                    "id": to_string(.body.workflow_job.run_id) ?? ""
+                    "id": to_string!(.body.workflow_job.run_id) + "/" + to_string!(.body.workflow_job.run_attempt),
                 }
             }
         }

--- a/examples/assets/outputs/transform-github_events/workflow_job/completed.out.json
+++ b/examples/assets/outputs/transform-github_events/workflow_job/completed.out.json
@@ -16,12 +16,12 @@
       "content": {
         "outcome": "success",
         "pipelineRun": {
-          "id": "12915191034"
+          "id": "12915191034/1"
         },
-        "taskName": "ci",
+        "taskName": "cdviz-dev/cdviz-collector/ci/ci",
         "url": "https://github.com/cdviz-dev/cdviz-collector/actions/runs/12915191034/job/36016488174"
       },
-      "id": "36016488174",
+      "id": "36016488174/1",
       "type": "taskRun"
     }
   }

--- a/examples/assets/outputs/transform-github_events/workflow_job/in_progress.out.json
+++ b/examples/assets/outputs/transform-github_events/workflow_job/in_progress.out.json
@@ -15,12 +15,12 @@
     "subject": {
       "content": {
         "pipelineRun": {
-          "id": "12915191049"
+          "id": "12915191049/1"
         },
-        "taskName": "MegaLinter",
+        "taskName": "cdviz-dev/cdviz-collector/MegaLinter/MegaLinter",
         "url": "https://github.com/cdviz-dev/cdviz-collector/actions/runs/12915191049/job/36016488192"
       },
-      "id": "36016488192",
+      "id": "36016488192/1",
       "type": "taskRun"
     }
   }

--- a/examples/assets/outputs/transform-github_events/workflow_run/completed.out.json
+++ b/examples/assets/outputs/transform-github_events/workflow_run/completed.out.json
@@ -15,10 +15,10 @@
     "subject": {
       "content": {
         "outcome": "success",
-        "pipelineName": "ci",
+        "pipelineName": "cdviz-dev/cdviz-collector/ci",
         "url": "https://github.com/cdviz-dev/cdviz-collector/actions/runs/12915191034"
       },
-      "id": "12915191034",
+      "id": "12915191034/1",
       "type": "pipelineRun"
     }
   }

--- a/examples/assets/outputs/transform-github_events/workflow_run/in_progress.out.json
+++ b/examples/assets/outputs/transform-github_events/workflow_run/in_progress.out.json
@@ -14,10 +14,10 @@
     },
     "subject": {
       "content": {
-        "pipelineName": "MegaLinter",
+        "pipelineName": "cdviz-dev/cdviz-collector/MegaLinter",
         "url": "https://github.com/cdviz-dev/cdviz-collector/actions/runs/12915191049"
       },
-      "id": "12915191049",
+      "id": "12915191049/1",
       "type": "pipelineRun"
     }
   }

--- a/examples/assets/outputs/transform-github_events/workflow_run/requested.out.json
+++ b/examples/assets/outputs/transform-github_events/workflow_run/requested.out.json
@@ -14,10 +14,10 @@
     },
     "subject": {
       "content": {
-        "pipelineName": "Release",
+        "pipelineName": "cdviz-dev/cdviz-collector/Release",
         "url": "https://github.com/cdviz-dev/cdviz-collector/actions/runs/12915191052"
       },
-      "id": "12915191052",
+      "id": "12915191052/1",
       "type": "pipelineRun"
     }
   }


### PR DESCRIPTION
- include the run_attempt, to differentiate 2 launch of same workflow (job & task)
- include the context into the pipelineName & task name to differentiate 2 entities with same name but from different repo or workflow