### PR TITLE
feat!(github): change the computation of `subject.id`, `context.sourc…

### DIFF
--- a/config/transformers/github_events.vrl
+++ b/config/transformers/github_events.vrl
@@ -23,11 +23,32 @@
 # | [x] | pull_request:* | change:updated |
 # | [x] | pull_request_review:submitted | change:reviewed |
 #
+# ## Rules:
+#
+# - `context.id` is computed by the collector (using content id, CID computed)
+# - `context.source` is the collector, not an url from github
+# - `subject.id` is the api url of the entity, except for artifacts usiong the package url (PURL)
+# - `subject.source` is empty, all information are in the `subject.id` (global id)
+# - `customData.github` follow the hierarchy of the github event, but only provides few fields
+#
 
 bodies = []
-id = "0" # "0" to let collector generate an id (alternative reuse github event id: .headers["X-GitHub-Delivery"])
+context_id = "0" # "0" to let collector generate an id (alternative reuse github event id: .headers["X-GitHub-Delivery"])
+# context_source = "https://api.github.com/repos/{{ .body.repository.full_name }}" ?? ""
+context_source = "cdviz-collector/github" # TODO: use collector URL or cdviz source's id
 repo_full_name = .body.repository.full_name
 sender = .body.sender.login
+custom_data = {
+  "github": {
+    "repository": {
+      "url": .body.repository.url,
+    },
+    "sender": {
+      "login": .body.sender.login,
+    },
+  }
+}
+
 # test existance of a field to determine the event type (alternative: .headers["X-GitHub-Event"])
 if exists(.body.package) {
   if .body.action == "published" {
@@ -94,8 +115,8 @@ if exists(.body.package) {
       {
         "context": {
           "version": "0.4.1",
-          "id": id,
-          "source": "/api.github.com/repos/{{ repo_full_name }}/packages" ?? "",
+          "id": context_id,
+          "source": context_source,
           "type": "dev.cdevents.artifact.published.0.2.0",
           "timestamp": ts,
           # "chainId": ??
@@ -108,7 +129,8 @@ if exists(.body.package) {
           "content": {
             "user": sender,
           }
-        }
+        },
+        "customData": custom_data,
       }
     }
   }
@@ -119,11 +141,19 @@ if exists(.body.package) {
     version = .body.release.tag_name
     # version = encode_percent(version) ?? ""
     pkg = "pkg:github/{{ repo_full_name }}@{{ version }}" ?? ""
+    custom_data.github.release = {
+      "url": .body.release.url,
+      # "tag_name": version,
+      # "name": .body.release.name,
+      # "description": .body.release.body,
+      # "draft": bool!(.body.release.draft || false),
+      # "prerelease": bool!(.body.release.prerelease || false),
+    }
     bodies = [{
       "context": {
         "version": "0.4.1",
-        "id": id,
-        "source": .body.release.url,
+        "id": context_id,
+        "source": context_source,
         "type": "dev.cdevents.artifact.published.0.2.0",
         "timestamp": ts,
         # "chainId": ??
@@ -135,7 +165,8 @@ if exists(.body.package) {
         "content": {
           "user": sender,
         }
-      }
+      },
+      "customData": custom_data,
     }]
   }
 } else if exists(.body.workflow_run) {
@@ -145,18 +176,19 @@ if exists(.body.package) {
   body = {
     "context": {
       "version": "0.4.1",
-      "id": id,
-      "source": .body.workflow_run.url,
+      "id": context_id,
+      "source": context_source,
       "timestamp": ts,
     },
     "subject": {
-      "id": to_string!(.body.workflow_run.id) + "/" + to_string!(.body.workflow_run.run_attempt) , # or .body.workflow_run.workflow_id, integration of run_number ?
+      "id": to_string!(.body.workflow_run.url) + "/attempts/" + to_string!(.body.workflow_run.run_attempt), # or .body.workflow_run.workflow_id, integration of run_number ?
       "type": "pipelineRun",
       "content": {
         "pipelineName": (repo_full_name + "/" + .body.workflow_run.name) ?? "",
-        "url": .body.workflow_run.html_url
+        "url": to_string!(.body.workflow_run.html_url) + "/attempts/" + to_string!(.body.workflow_run.run_attempt),
       }
-    }
+    },
+    "customData": custom_data,
   }
   if .body.action == "requested" {
     body.context.type = "dev.cdevents.pipelinerun.queued.0.2.0"
@@ -174,21 +206,22 @@ if exists(.body.package) {
   body = {
     "context": {
       "version": "0.4.1",
-      "id": id,
-      "source": .body.workflow_job.url,
+      "id": context_id,
+      "source": context_source, #.body.workflow_job.url,
     },
     "subject": {
-      "id": to_string!(.body.workflow_job.id) + "/" + to_string!(.body.workflow_job.run_attempt),
+      "id": .body.workflow_job.url,
       "type": "taskRun",
       "content": {
         # define an "absolute" name to avoid conflicts with other entities from other contexts
         "taskName": (repo_full_name + "/" + .body.workflow_job.workflow_name + "/" + .body.workflow_job.name) ?? .body.workflow_job.name,
         "url": .body.workflow_job.html_url,
         "pipelineRun": {
-          "id": to_string!(.body.workflow_job.run_id) + "/" + to_string!(.body.workflow_job.run_attempt),
+          "id": to_string!(.body.workflow_job.run_url) + "/attempts/" + to_string!(.body.workflow_job.run_attempt),
         }
       }
-    }
+    },
+    "customData": custom_data,
   }
   if .body.action == "in_progress" {
     ts = parse_timestamp(.body.workflow_job.started_at, "%+") ?? now()
@@ -210,8 +243,8 @@ if exists(.body.package) {
   body = {
     "context": {
       "version": "0.4.1",
-      "id": id,
-      "source": .body.issue.url,
+      "id": context_id,
+      "source": context_source,
       # "chainId": ??
       # "links": ??
     },
@@ -233,7 +266,8 @@ if exists(.body.package) {
         "milestone": .body.issue.milestone.title,
         "uri": .body.issue.html_url,
       }
-    }
+    },
+    "customData": custom_data,
   }
   if .body.action == "opened" {
     ts = parse_timestamp(.body.issue.created_at, "%+") ?? now()
@@ -255,11 +289,7 @@ if exists(.body.package) {
     body.context.type = "dev.cdevents.ticket.updated.0.1.0"
     body.context.timestamp = ts
     body.subject.content.updatedBy = .body.sender.login
-    body.customData = {
-      "issue": {
-        "action": .body.action # edited, transferred, reopened, locked, unlocked, milestoned, demilestoned
-      }
-    }
+    body.customData.github.action = .body.action # edited, transferred, reopened, locked, unlocked, milestoned, demilestoned
     bodies = [body]
   }
 } else if exists(.body.ref) {
@@ -267,8 +297,8 @@ if exists(.body.package) {
     body = {
       "context": {
         "version": "0.4.1",
-        "id": id,
-        "source": .body.repository.url,
+        "id": context_id,
+        "source": context_source,
         # "chainId": ??
         # "links": ??
       },
@@ -280,7 +310,8 @@ if exists(.body.package) {
             "id": .body.repository.url,
           }
         }
-      }
+      },
+      "customData": custom_data,
     }
     ts = parse_timestamp(.body.head_commit.timestamp, "%+") ?? now()
     ts = format_timestamp!(ts, format: "%+")
@@ -299,8 +330,8 @@ if exists(.body.package) {
   body = {
     "context": {
       "version": "0.4.1",
-      "id": id,
-      "source": .body.repository.url,
+      "id": context_id,
+      "source": context_source,
       # "chainId": ??
       # "links": ??
     },
@@ -312,7 +343,8 @@ if exists(.body.package) {
           "id": .body.repository.url,
         }
       }
-    }
+    },
+    "customData": custom_data,
   }
   if exists(.body.review) {
     if .body.action == "submitted" && .body.review.state != "approved" {
@@ -320,15 +352,11 @@ if exists(.body.package) {
       ts = format_timestamp!(ts, format: "%+")
       body.context.timestamp = ts
       body.context.type = "dev.cdevents.change.reviewed.0.2.0"
-      body.customData = {
-        "pull_request_review": {
-          "action": .body.action,
-          "review": {
-            "state": .body.review.state, # approved, changes_requested, dismissed
-            "author": .body.review.user.login,
-            "url": .body.review.html_url
-          }
-        }
+      body.customData.github.action = .body.action # submitted, dismissed, edited
+      body.customData.github.review = {
+        "state": .body.review.state, # approved, changes_requested, dismissed
+        "author": .body.review.user.login,
+        "url": .body.review.html_url
       }
       bodies = [body]
     }
@@ -355,11 +383,7 @@ if exists(.body.package) {
     ts = format_timestamp!(ts, format: "%+")
     body.context.timestamp = ts
     body.context.type = "dev.cdevents.change.updated.0.2.0"
-    body.customData = {
-      "pull_request": {
-        "action": .body.action
-      }
-    }
+    body.customData.github.action = .body.action
     bodies = [body]
   }
 }

--- a/examples/assets/outputs/transform-github_events/branch/event.02.out.json
+++ b/examples/assets/outputs/transform-github_events/branch/event.02.out.json
@@ -7,10 +7,20 @@
   "body": {
     "context": {
       "id": "0",
-      "source": "https://api.github.com/repos/aaaaa-aaa/aaaaa-aaaaaaaaa",
+      "source": "cdviz-collector/github",
       "timestamp": "2025-05-21T13:17:24+00:00",
       "type": "dev.cdevents.branch.created.0.2.0",
       "version": "0.4.1"
+    },
+    "customData": {
+      "github": {
+        "repository": {
+          "url": "https://api.github.com/repos/aaaaa-aaa/aaaaa-aaaaaaaaa"
+        },
+        "sender": {
+          "login": "aaaaaA"
+        }
+      }
     },
     "subject": {
       "content": {

--- a/examples/assets/outputs/transform-github_events/branch/event.08.out.json
+++ b/examples/assets/outputs/transform-github_events/branch/event.08.out.json
@@ -7,10 +7,20 @@
   "body": {
     "context": {
       "id": "0",
-      "source": "https://api.github.com/repos/aaaaa-aaa/aaaaa-aaaaaaaaa",
+      "source": "cdviz-collector/github",
       "timestamp": "2025-05-21T17:35:21+00:00",
       "type": "dev.cdevents.branch.created.0.2.0",
       "version": "0.4.1"
+    },
+    "customData": {
+      "github": {
+        "repository": {
+          "url": "https://api.github.com/repos/aaaaa-aaa/aaaaa-aaaaaaaaa"
+        },
+        "sender": {
+          "login": "aaaaaa-aaaaaaa[aaa]"
+        }
+      }
     },
     "subject": {
       "content": {

--- a/examples/assets/outputs/transform-github_events/issue/assigned.01.out.json
+++ b/examples/assets/outputs/transform-github_events/issue/assigned.01.out.json
@@ -7,14 +7,20 @@
   "body": {
     "context": {
       "id": "0",
-      "source": "https://api.github.com/repos/aaaaa-aaa/aaaaa-aaaaaaaaa/issues/98",
+      "source": "cdviz-collector/github",
       "timestamp": "2025-05-21T17:44:53+00:00",
       "type": "dev.cdevents.ticket.updated.0.1.0",
       "version": "0.4.1"
     },
     "customData": {
-      "issue": {
-        "action": "assigned"
+      "github": {
+        "action": "assigned",
+        "repository": {
+          "url": "https://api.github.com/repos/aaaaa-aaa/aaaaa-aaaaaaaaa"
+        },
+        "sender": {
+          "login": "aaaaaA"
+        }
       }
     },
     "subject": {

--- a/examples/assets/outputs/transform-github_events/issue/closed.01.out.json
+++ b/examples/assets/outputs/transform-github_events/issue/closed.01.out.json
@@ -7,10 +7,20 @@
   "body": {
     "context": {
       "id": "0",
-      "source": "https://api.github.com/repos/aaaaa-aaa/aaaaa-aaaaaaaaa/issues/98",
+      "source": "cdviz-collector/github",
       "timestamp": "2025-05-21T17:46:53+00:00",
       "type": "dev.cdevents.ticket.closed.0.1.0",
       "version": "0.4.1"
+    },
+    "customData": {
+      "github": {
+        "repository": {
+          "url": "https://api.github.com/repos/aaaaa-aaa/aaaaa-aaaaaaaaa"
+        },
+        "sender": {
+          "login": "aaaaaA"
+        }
+      }
     },
     "subject": {
       "content": {

--- a/examples/assets/outputs/transform-github_events/issue/closed.02.out.json
+++ b/examples/assets/outputs/transform-github_events/issue/closed.02.out.json
@@ -7,10 +7,20 @@
   "body": {
     "context": {
       "id": "0",
-      "source": "https://api.github.com/repos/aaaaa-aaa/aaaaa-aaaaaaaaa/issues/98",
+      "source": "cdviz-collector/github",
       "timestamp": "2025-05-21T17:49:53+00:00",
       "type": "dev.cdevents.ticket.closed.0.1.0",
       "version": "0.4.1"
+    },
+    "customData": {
+      "github": {
+        "repository": {
+          "url": "https://api.github.com/repos/aaaaa-aaa/aaaaa-aaaaaaaaa"
+        },
+        "sender": {
+          "login": "aaaaaA"
+        }
+      }
     },
     "subject": {
       "content": {

--- a/examples/assets/outputs/transform-github_events/issue/labeled.01.out.json
+++ b/examples/assets/outputs/transform-github_events/issue/labeled.01.out.json
@@ -7,14 +7,20 @@
   "body": {
     "context": {
       "id": "0",
-      "source": "https://api.github.com/repos/aaaaa-aaa/aaaaa-aaaaaaaaa/issues/98",
+      "source": "cdviz-collector/github",
       "timestamp": "2025-05-21T17:43:50+00:00",
       "type": "dev.cdevents.ticket.updated.0.1.0",
       "version": "0.4.1"
     },
     "customData": {
-      "issue": {
-        "action": "labeled"
+      "github": {
+        "action": "labeled",
+        "repository": {
+          "url": "https://api.github.com/repos/aaaaa-aaa/aaaaa-aaaaaaaaa"
+        },
+        "sender": {
+          "login": "aaaaaA"
+        }
       }
     },
     "subject": {

--- a/examples/assets/outputs/transform-github_events/issue/labeled.02.out.json
+++ b/examples/assets/outputs/transform-github_events/issue/labeled.02.out.json
@@ -7,14 +7,20 @@
   "body": {
     "context": {
       "id": "0",
-      "source": "https://api.github.com/repos/aaaaa-aaa/aaaaa-aaaaaaaaa/issues/98",
+      "source": "cdviz-collector/github",
       "timestamp": "2025-05-21T17:45:34+00:00",
       "type": "dev.cdevents.ticket.updated.0.1.0",
       "version": "0.4.1"
     },
     "customData": {
-      "issue": {
-        "action": "labeled"
+      "github": {
+        "action": "labeled",
+        "repository": {
+          "url": "https://api.github.com/repos/aaaaa-aaa/aaaaa-aaaaaaaaa"
+        },
+        "sender": {
+          "login": "aaaaaA"
+        }
       }
     },
     "subject": {

--- a/examples/assets/outputs/transform-github_events/issue/opened.01.out.json
+++ b/examples/assets/outputs/transform-github_events/issue/opened.01.out.json
@@ -7,10 +7,20 @@
   "body": {
     "context": {
       "id": "0",
-      "source": "https://api.github.com/repos/aaaaa-aaa/aaaaa-aaaaaaaaa/issues/98",
+      "source": "cdviz-collector/github",
       "timestamp": "2025-05-21T17:43:50+00:00",
       "type": "dev.cdevents.ticket.created.0.1.0",
       "version": "0.4.1"
+    },
+    "customData": {
+      "github": {
+        "repository": {
+          "url": "https://api.github.com/repos/aaaaa-aaa/aaaaa-aaaaaaaaa"
+        },
+        "sender": {
+          "login": "aaaaaA"
+        }
+      }
     },
     "subject": {
       "content": {

--- a/examples/assets/outputs/transform-github_events/issue/reopened.01.out.json
+++ b/examples/assets/outputs/transform-github_events/issue/reopened.01.out.json
@@ -7,14 +7,20 @@
   "body": {
     "context": {
       "id": "0",
-      "source": "https://api.github.com/repos/aaaaa-aaa/aaaaa-aaaaaaaaa/issues/98",
+      "source": "cdviz-collector/github",
       "timestamp": "2025-05-21T17:49:23+00:00",
       "type": "dev.cdevents.ticket.updated.0.1.0",
       "version": "0.4.1"
     },
     "customData": {
-      "issue": {
-        "action": "reopened"
+      "github": {
+        "action": "reopened",
+        "repository": {
+          "url": "https://api.github.com/repos/aaaaa-aaa/aaaaa-aaaaaaaaa"
+        },
+        "sender": {
+          "login": "aaaaaA"
+        }
       }
     },
     "subject": {

--- a/examples/assets/outputs/transform-github_events/issue/unlabeled.01.out.json
+++ b/examples/assets/outputs/transform-github_events/issue/unlabeled.01.out.json
@@ -7,14 +7,20 @@
   "body": {
     "context": {
       "id": "0",
-      "source": "https://api.github.com/repos/aaaaa-aaa/aaaaa-aaaaaaaaa/issues/98",
+      "source": "cdviz-collector/github",
       "timestamp": "2025-05-21T17:45:34+00:00",
       "type": "dev.cdevents.ticket.updated.0.1.0",
       "version": "0.4.1"
     },
     "customData": {
-      "issue": {
-        "action": "unlabeled"
+      "github": {
+        "action": "unlabeled",
+        "repository": {
+          "url": "https://api.github.com/repos/aaaaa-aaa/aaaaa-aaaaaaaaa"
+        },
+        "sender": {
+          "login": "aaaaaA"
+        }
       }
     },
     "subject": {

--- a/examples/assets/outputs/transform-github_events/package/published.4.out.json
+++ b/examples/assets/outputs/transform-github_events/package/published.4.out.json
@@ -7,10 +7,20 @@
   "body": {
     "context": {
       "id": "0",
-      "source": "/api.github.com/repos/aaaaa-aaa/aaaaa-aaaaaaaaa/packages",
+      "source": "cdviz-collector/github",
       "timestamp": "2025-01-24T14:31:36+00:00",
       "type": "dev.cdevents.artifact.published.0.2.0",
       "version": "0.4.1"
+    },
+    "customData": {
+      "github": {
+        "repository": {
+          "url": "https://api.github.com/repos/aaaaa-aaa/aaaaa-aaaaaaaaa"
+        },
+        "sender": {
+          "login": "aaaaaa-aaaaaaa[aaa]"
+        }
+      }
     },
     "subject": {
       "content": {

--- a/examples/assets/outputs/transform-github_events/pull_request/closed.01.out.json
+++ b/examples/assets/outputs/transform-github_events/pull_request/closed.01.out.json
@@ -7,10 +7,20 @@
   "body": {
     "context": {
       "id": "0",
-      "source": "https://api.github.com/repos/aaaaa-aaa/aaaaa-aaaaaaaaa",
+      "source": "cdviz-collector/github",
       "timestamp": "2025-05-21T17:35:21+00:00",
       "type": "dev.cdevents.change.merged.0.2.0",
       "version": "0.4.1"
+    },
+    "customData": {
+      "github": {
+        "repository": {
+          "url": "https://api.github.com/repos/aaaaa-aaa/aaaaa-aaaaaaaaa"
+        },
+        "sender": {
+          "login": "aaaaaA"
+        }
+      }
     },
     "subject": {
       "content": {

--- a/examples/assets/outputs/transform-github_events/pull_request/edited.01.out.json
+++ b/examples/assets/outputs/transform-github_events/pull_request/edited.01.out.json
@@ -7,14 +7,20 @@
   "body": {
     "context": {
       "id": "0",
-      "source": "https://api.github.com/repos/aaaaa-aaa/aaaaa-aaaaaaaaa",
+      "source": "cdviz-collector/github",
       "timestamp": "2025-05-21T17:36:04+00:00",
       "type": "dev.cdevents.change.updated.0.2.0",
       "version": "0.4.1"
     },
     "customData": {
-      "pull_request": {
-        "action": "edited"
+      "github": {
+        "action": "edited",
+        "repository": {
+          "url": "https://api.github.com/repos/aaaaa-aaa/aaaaa-aaaaaaaaa"
+        },
+        "sender": {
+          "login": "aaaaaa-aaaaaaa[aaa]"
+        }
       }
     },
     "subject": {

--- a/examples/assets/outputs/transform-github_events/pull_request/opened.01.out.json
+++ b/examples/assets/outputs/transform-github_events/pull_request/opened.01.out.json
@@ -7,10 +7,20 @@
   "body": {
     "context": {
       "id": "0",
-      "source": "https://api.github.com/repos/aaaaa-aaa/aaaaa-aaaaaaaaa",
+      "source": "cdviz-collector/github",
       "timestamp": "2025-05-21T14:28:11+00:00",
       "type": "dev.cdevents.change.created.0.3.0",
       "version": "0.4.1"
+    },
+    "customData": {
+      "github": {
+        "repository": {
+          "url": "https://api.github.com/repos/aaaaa-aaa/aaaaa-aaaaaaaaa"
+        },
+        "sender": {
+          "login": "aaaaaA"
+        }
+      }
     },
     "subject": {
       "content": {

--- a/examples/assets/outputs/transform-github_events/pull_request/synchronize.01.out.json
+++ b/examples/assets/outputs/transform-github_events/pull_request/synchronize.01.out.json
@@ -7,14 +7,20 @@
   "body": {
     "context": {
       "id": "0",
-      "source": "https://api.github.com/repos/aaaaa-aaa/aaaaa-aaaaaaaaa",
+      "source": "cdviz-collector/github",
       "timestamp": "2025-05-21T14:30:21+00:00",
       "type": "dev.cdevents.change.updated.0.2.0",
       "version": "0.4.1"
     },
     "customData": {
-      "pull_request": {
-        "action": "synchronize"
+      "github": {
+        "action": "synchronize",
+        "repository": {
+          "url": "https://api.github.com/repos/aaaaa-aaa/aaaaa-aaaaaaaaa"
+        },
+        "sender": {
+          "login": "aaaaaA"
+        }
       }
     },
     "subject": {

--- a/examples/assets/outputs/transform-github_events/pull_request/synchronize.02.out.json
+++ b/examples/assets/outputs/transform-github_events/pull_request/synchronize.02.out.json
@@ -7,14 +7,20 @@
   "body": {
     "context": {
       "id": "0",
-      "source": "https://api.github.com/repos/aaaaa-aaa/aaaaa-aaaaaaaaa",
+      "source": "cdviz-collector/github",
       "timestamp": "2025-05-21T14:55:34+00:00",
       "type": "dev.cdevents.change.updated.0.2.0",
       "version": "0.4.1"
     },
     "customData": {
-      "pull_request": {
-        "action": "synchronize"
+      "github": {
+        "action": "synchronize",
+        "repository": {
+          "url": "https://api.github.com/repos/aaaaa-aaa/aaaaa-aaaaaaaaa"
+        },
+        "sender": {
+          "login": "aaaaaA"
+        }
       }
     },
     "subject": {

--- a/examples/assets/outputs/transform-github_events/pull_request/synchronize.03.out.json
+++ b/examples/assets/outputs/transform-github_events/pull_request/synchronize.03.out.json
@@ -7,14 +7,20 @@
   "body": {
     "context": {
       "id": "0",
-      "source": "https://api.github.com/repos/aaaaa-aaa/aaaaa-aaaaaaaaa",
+      "source": "cdviz-collector/github",
       "timestamp": "2025-05-21T17:36:04+00:00",
       "type": "dev.cdevents.change.updated.0.2.0",
       "version": "0.4.1"
     },
     "customData": {
-      "pull_request": {
-        "action": "synchronize"
+      "github": {
+        "action": "synchronize",
+        "repository": {
+          "url": "https://api.github.com/repos/aaaaa-aaa/aaaaa-aaaaaaaaa"
+        },
+        "sender": {
+          "login": "aaaaaa-aaaaaaa[aaa]"
+        }
       }
     },
     "subject": {

--- a/examples/assets/outputs/transform-github_events/release/published.out.json
+++ b/examples/assets/outputs/transform-github_events/release/published.out.json
@@ -7,10 +7,23 @@
   "body": {
     "context": {
       "id": "0",
-      "source": "https://api.github.com/repos/aaaaa-aaa/aaaaa-aaaaaaaaa/releases/111111111",
+      "source": "cdviz-collector/github",
       "timestamp": "2025-01-24T14:30:24+00:00",
       "type": "dev.cdevents.artifact.published.0.2.0",
       "version": "0.4.1"
+    },
+    "customData": {
+      "github": {
+        "release": {
+          "url": "https://api.github.com/repos/aaaaa-aaa/aaaaa-aaaaaaaaa/releases/111111111"
+        },
+        "repository": {
+          "url": "https://api.github.com/repos/aaaaa-aaa/aaaaa-aaaaaaaaa"
+        },
+        "sender": {
+          "login": "aaaaaa-aaaaaaa[aaa]"
+        }
+      }
     },
     "subject": {
       "content": {

--- a/examples/assets/outputs/transform-github_events/workflow_job/completed.out.json
+++ b/examples/assets/outputs/transform-github_events/workflow_job/completed.out.json
@@ -7,21 +7,31 @@
   "body": {
     "context": {
       "id": "0",
-      "source": "https://api.github.com/repos/aaaaa-aaa/aaaaa-aaaaaaaaa/actions/jobs/11111111111",
+      "source": "cdviz-collector/github",
       "timestamp": "1015-01-11T19:03:48+00:00",
       "type": "dev.cdevents.taskrun.finished.0.2.0",
       "version": "0.4.1"
+    },
+    "customData": {
+      "github": {
+        "repository": {
+          "url": "https://api.github.com/repos/aaaaa-aaa/aaaaa-aaaaaaaaa"
+        },
+        "sender": {
+          "login": "aaaaaA"
+        }
+      }
     },
     "subject": {
       "content": {
         "outcome": "success",
         "pipelineRun": {
-          "id": "11111111111/1"
+          "id": "https://api.github.com/repos/aaaaa-aaa/aaaaa-aaaaaaaaa/actions/runs/11111111111/attempts/1"
         },
         "taskName": "aaaaa-aaa/aaaaa-aaaaaaaaa/aa/aa",
         "url": "https://github.com/aaaaa-aaa/aaaaa-aaaaaaaaa/actions/runs/11111111111/job/11111111111"
       },
-      "id": "11111111111/1",
+      "id": "https://api.github.com/repos/aaaaa-aaa/aaaaa-aaaaaaaaa/actions/jobs/11111111111",
       "type": "taskRun"
     }
   }

--- a/examples/assets/outputs/transform-github_events/workflow_job/in_progress.out.json
+++ b/examples/assets/outputs/transform-github_events/workflow_job/in_progress.out.json
@@ -7,20 +7,30 @@
   "body": {
     "context": {
       "id": "0",
-      "source": "https://api.github.com/repos/aaaaa-aaa/aaaaa-aaaaaaaaa/actions/jobs/11111111111",
+      "source": "cdviz-collector/github",
       "timestamp": "1015-01-11T19:01:11+00:00",
       "type": "dev.cdevents.taskrun.started.0.2.0",
       "version": "0.4.1"
     },
+    "customData": {
+      "github": {
+        "repository": {
+          "url": "https://api.github.com/repos/aaaaa-aaa/aaaaa-aaaaaaaaa"
+        },
+        "sender": {
+          "login": "aaaaaA"
+        }
+      }
+    },
     "subject": {
       "content": {
         "pipelineRun": {
-          "id": "11111111111/1"
+          "id": "https://api.github.com/repos/aaaaa-aaa/aaaaa-aaaaaaaaa/actions/runs/11111111111/attempts/1"
         },
         "taskName": "aaaaa-aaa/aaaaa-aaaaaaaaa/AaaaAaaaaa/AaaaAaaaaa",
         "url": "https://github.com/aaaaa-aaa/aaaaa-aaaaaaaaa/actions/runs/11111111111/job/11111111111"
       },
-      "id": "11111111111/1",
+      "id": "https://api.github.com/repos/aaaaa-aaa/aaaaa-aaaaaaaaa/actions/jobs/11111111111",
       "type": "taskRun"
     }
   }

--- a/examples/assets/outputs/transform-github_events/workflow_run/completed.out.json
+++ b/examples/assets/outputs/transform-github_events/workflow_run/completed.out.json
@@ -7,18 +7,28 @@
   "body": {
     "context": {
       "id": "0",
-      "source": "https://api.github.com/repos/aaaaa-aaa/aaaaa-aaaaaaaaa/actions/runs/11111111111",
+      "source": "cdviz-collector/github",
       "timestamp": "2025-01-22T19:03:50+00:00",
       "type": "dev.cdevents.pipelinerun.finished.0.2.0",
       "version": "0.4.1"
+    },
+    "customData": {
+      "github": {
+        "repository": {
+          "url": "https://api.github.com/repos/aaaaa-aaa/aaaaa-aaaaaaaaa"
+        },
+        "sender": {
+          "login": "aaaaaA"
+        }
+      }
     },
     "subject": {
       "content": {
         "outcome": "success",
         "pipelineName": "aaaaa-aaa/aaaaa-aaaaaaaaa/aa",
-        "url": "https://github.com/aaaaa-aaa/aaaaa-aaaaaaaaa/actions/runs/11111111111"
+        "url": "https://github.com/aaaaa-aaa/aaaaa-aaaaaaaaa/actions/runs/11111111111/attempts/1"
       },
-      "id": "11111111111/1",
+      "id": "https://api.github.com/repos/aaaaa-aaa/aaaaa-aaaaaaaaa/actions/runs/11111111111/attempts/1",
       "type": "pipelineRun"
     }
   }

--- a/examples/assets/outputs/transform-github_events/workflow_run/in_progress.out.json
+++ b/examples/assets/outputs/transform-github_events/workflow_run/in_progress.out.json
@@ -7,17 +7,27 @@
   "body": {
     "context": {
       "id": "0",
-      "source": "https://api.github.com/repos/aaaaa-aaa/aaaaa-aaaaaaaaa/actions/runs/11111111111",
+      "source": "cdviz-collector/github",
       "timestamp": "2025-01-22T19:01:11+00:00",
       "type": "dev.cdevents.pipelinerun.started.0.2.0",
       "version": "0.4.1"
     },
+    "customData": {
+      "github": {
+        "repository": {
+          "url": "https://api.github.com/repos/aaaaa-aaa/aaaaa-aaaaaaaaa"
+        },
+        "sender": {
+          "login": "aaaaaA"
+        }
+      }
+    },
     "subject": {
       "content": {
         "pipelineName": "aaaaa-aaa/aaaaa-aaaaaaaaa/AaaaAaaaaa",
-        "url": "https://github.com/aaaaa-aaa/aaaaa-aaaaaaaaa/actions/runs/11111111111"
+        "url": "https://github.com/aaaaa-aaa/aaaaa-aaaaaaaaa/actions/runs/11111111111/attempts/1"
       },
-      "id": "11111111111/1",
+      "id": "https://api.github.com/repos/aaaaa-aaa/aaaaa-aaaaaaaaa/actions/runs/11111111111/attempts/1",
       "type": "pipelineRun"
     }
   }

--- a/examples/assets/outputs/transform-github_events/workflow_run/requested.out.json
+++ b/examples/assets/outputs/transform-github_events/workflow_run/requested.out.json
@@ -7,17 +7,27 @@
   "body": {
     "context": {
       "id": "0",
-      "source": "https://api.github.com/repos/aaaaa-aaa/aaaaa-aaaaaaaaa/actions/runs/11111111111",
+      "source": "cdviz-collector/github",
       "timestamp": "2025-01-22T19:01:00+00:00",
       "type": "dev.cdevents.pipelinerun.queued.0.2.0",
       "version": "0.4.1"
     },
+    "customData": {
+      "github": {
+        "repository": {
+          "url": "https://api.github.com/repos/aaaaa-aaa/aaaaa-aaaaaaaaa"
+        },
+        "sender": {
+          "login": "aaaaaA"
+        }
+      }
+    },
     "subject": {
       "content": {
         "pipelineName": "aaaaa-aaa/aaaaa-aaaaaaaaa/Aaaaaaa",
-        "url": "https://github.com/aaaaa-aaa/aaaaa-aaaaaaaaa/actions/runs/11111111111"
+        "url": "https://github.com/aaaaa-aaa/aaaaa-aaaaaaaaa/actions/runs/11111111111/attempts/1"
       },
-      "id": "11111111111/1",
+      "id": "https://api.github.com/repos/aaaaa-aaa/aaaaa-aaaaaaaaa/actions/runs/11111111111/attempts/1",
       "type": "pipelineRun"
     }
   }


### PR DESCRIPTION
…e`, `customData`,...

- `context.id` is computed by the collector (using content id, CID computed)
- `context.source` is the collector, not an url from github
- `subject.id` is the api url of the entity, except for artifacts usiong the package url (PURL)
- `subject.source` is empty, all information are in the `subject.id` (global id)
- `customData.github` follow the hierarchy of the github event, but only provides few fields